### PR TITLE
Changing the exec command behaviour to work with files.

### DIFF
--- a/src/commands/exec/mod.rs
+++ b/src/commands/exec/mod.rs
@@ -330,7 +330,6 @@ fn exec(ctx: &mut Context, msg: &Message) -> CommandResult {
             None => {file_list.push(attachment)}, // Other file don't
         }
     }
-    // println!("Attachment lenght: {0} , Files: {1}",attachments.len(),file_list.len());
 
     let langs = data
         .get::<LangManager>()
@@ -339,7 +338,6 @@ fn exec(ctx: &mut Context, msg: &Message) -> CommandResult {
         .unwrap()
         .get_languages_list();
     drop(data);
-    //let mut ret = None;
 
     if split.clone().nth(1).is_none() {
         let _ = msg.reply(&ctx, &format!("Please add a code section to your message\nExample:\n{}exec\n\\`\\`\\`language\n**code**\n\\`\\`\\`\nHere are the languages available: {}", settings.command_prefix, langs))?;
@@ -383,8 +381,6 @@ fn exec(ctx: &mut Context, msg: &Message) -> CommandResult {
         }
     };
     code.push_str(text.as_str());
-
-    println!("Here is the code : {}", code);
 
     let mut reply_msg: Message;
     let (mut compilation, mut execution, lang) = {

--- a/src/commands/exec/mod.rs
+++ b/src/commands/exec/mod.rs
@@ -363,9 +363,25 @@ fn exec(ctx: &mut Context, msg: &Message) -> CommandResult {
                 Err(_) => {},
             }
         }
-   	}
+   	} else if file_list.len() > 0 {
+        while let Some(file) = file_list.pop() {
+            let result = file.download();
+            let mut _resultingstring = String::new();
+            match result {
+                Ok(vector) => {
+                    match String::from_utf8(vector) {
+                        Ok(result) =>{
+                            _resultingstring.push_str(result.as_str());
+                            ret = Some(_resultingstring);
+                        },
+                        Err(_) => {}
+                    }
+                },
+                Err(_) => {}
+            }
+        }
+    }
     let mut code = String::new();
-
     match ret {
         None => {
             let tmp = split.take(2).collect::<Vec<_>>()[1];

--- a/src/commands/exec/mod.rs
+++ b/src/commands/exec/mod.rs
@@ -364,6 +364,7 @@ fn exec(ctx: &mut Context, msg: &Message) -> CommandResult {
             }
         }
    	} else if file_list.len() > 0 {
+    println!("Third Case");
         while let Some(file) = file_list.pop() {
             let result = file.download();
             let mut _resultingstring = String::new();
@@ -412,9 +413,9 @@ fn exec(ctx: &mut Context, msg: &Message) -> CommandResult {
             	let tmp = tmp_split.take(2).collect::<Vec<_>>()[0] ;
             	code.insert_str(0,tmp);}
 	    else{
-		    let tmp = tmp_split.clone().take(2).collect::<Vec<_>>()[1] ;
+		    let tmp = tmp_split.clone().take(3).collect::<Vec<_>>()[1] ;
             	code.insert_str(0,tmp);
-		    let tmp_1 = tmp_split.take(2).collect::<Vec<_>>()[2] ;
+		    let tmp_1 = tmp_split.take(3).collect::<Vec<_>>()[2] ;
             	code.insert_str(0,tmp_1);
             }
         }

--- a/src/commands/exec/mod.rs
+++ b/src/commands/exec/mod.rs
@@ -379,9 +379,10 @@ fn exec(ctx: &mut Context, msg: &Message) -> CommandResult {
                 },
                 Err(_) => {}
             }
-        }
+    }
 	match ret {
 		Some(res_1) => {
+            println!("{}", res_1);
             let mut result= res_1.clone();
            	let mut tmp =String::new();
             let t = split.clone().take(2).collect::<Vec<_>>()[1];

--- a/src/commands/exec/mod.rs
+++ b/src/commands/exec/mod.rs
@@ -330,6 +330,7 @@ fn exec(ctx: &mut Context, msg: &Message) -> CommandResult {
             None => {file_list.push(attachment)},
         }
     }
+    println!("Attachment lenght:{0} , Files{1}",attachments.len(),file_list.len());
 
     let langs = data
         .get::<LangManager>()

--- a/src/commands/exec/mod.rs
+++ b/src/commands/exec/mod.rs
@@ -380,6 +380,22 @@ fn exec(ctx: &mut Context, msg: &Message) -> CommandResult {
                 Err(_) => {}
             }
         }
+	match ret {
+		Some(mut result) => {
+           	let mut tmp =String::new();
+            let t = split.clone().take(2).collect::<Vec<_>>()[1];
+            tmp.push_str(t);
+    		let mut sp = tmp.split('\n');
+            let code;
+    	    match sp.next() {
+            Some(_) => {
+                code = sp.collect::<Vec<_>>().join("\n");
+	            result.push_str(code.as_str());
+		    },
+	        None => {}
+	        }
+            ret = Some(result)
+    }, None => {}}
     }
     let mut code = String::new();
     match ret {

--- a/src/commands/exec/mod.rs
+++ b/src/commands/exec/mod.rs
@@ -339,91 +339,32 @@ fn exec(ctx: &mut Context, msg: &Message) -> CommandResult {
         .unwrap()
         .get_languages_list();
     drop(data);
-    let mut ret = None;
+    //let mut ret = None;
 
-    if split.clone().nth(1).is_none() && file_list.len() ==0  {
+    if split.clone().nth(1).is_none() {
         let _ = msg.reply(&ctx, &format!("Please add a code section to your message\nExample:\n{}exec\n\\`\\`\\`language\n**code**\n\\`\\`\\`\nHere are the languages available: {}", settings.command_prefix, langs))?;
         return Ok(());
     } 
-    else if split.clone().nth(1).is_none() {
-	println!("Second Case");
+    let mut code= String::new();
+    if file_list.len()> 0 {
         while let Some(file) = file_list.pop() {
             let result = file.download();
             match result {
-                // Ok(Vec<u8>) 
-                Ok(vector) => {
-                    match String::from_utf8(vector) {
-                        Ok(result) => {
-                            ret = Some(result);
-                            break;
-                        },
-                        Err(_) => {},
-                    }
-                },
                 Err(_) => {},
-            }
-        }
-   	} else if file_list.len() > 0 {
-    println!("Third Case");
-        while let Some(file) = file_list.pop() {
-            let result = file.download();
-            let mut _resultingstring = String::new();
-            match result {
                 Ok(vector) => {
                     match String::from_utf8(vector) {
-                        Ok(result) => {
-                            _resultingstring.push_str(result.as_str());
-                            ret = Some(_resultingstring);
-                        },
-                        Err(_) => {}
+                        Err(_) => {},
+                        Ok(string) => {
+                            code.push_str(string.as_str());
+                        }
                     }
-                },
-                Err(_) => {}
-            }
-    }
-	match ret {
-		Some(res_1) => {
-            println!("{}", res_1);
-            let mut result= res_1.clone();
-           	let mut tmp =String::new();
-            let t = split.clone().take(2).collect::<Vec<_>>()[1];
-            tmp.push_str(t);
-    		let mut sp = tmp.split('\n');
-            let code;
-    	    match sp.next() {
-            Some(_) => {
-                code = sp.collect::<Vec<_>>().join("\n");
-	            result.push_str(code.as_str());
-		    },
-	        None => {}
-	        }
-            ret = Some(result)
-        }, None => {}}
-    }
-    let mut code = String::new();
-    match ret {
-        None => {
-            let tmp = split.take(2).collect::<Vec<_>>()[1];
-            code.insert_str(0,tmp);
-        },
-        Some(t) => {
-        println!("Here is the result: {}", t);
-	    let tmp_split = t.split("```");
-	        if tmp_split.clone().nth(1).is_none() {
-            	let tmp = tmp_split.take(2).collect::<Vec<_>>()[0] ;
-            	code.insert_str(0,tmp);}
-	    else{
-		    let tmp = tmp_split.clone().take(3).collect::<Vec<_>>()[1] ;
-            	code.insert_str(0,tmp);
-		    let tmp_1 = tmp_split.take(3).collect::<Vec<_>>()[2] ;
-            	code.insert_str(0,tmp_1);
+                }
             }
         }
     }
-    println!("Here is the code : {}", code);
-
-    let mut split = code.split('\n');
-    let (lang_code, code) = match split.next() {
+    let tmp = split.clone().take(2).collect::<Vec<_>>().join("\n");
+    let mut split = tmp.split('\n');
+    let (lang_code, text) = match split.next() {
         Some(line) => {
             let code = split.collect::<Vec<_>>().join("\n");
             let lang = line.trim().to_ascii_lowercase();
@@ -440,6 +381,9 @@ fn exec(ctx: &mut Context, msg: &Message) -> CommandResult {
             return Ok(());
         }
     };
+    code.push_str(text.as_str());
+
+    println!("Here is the code : {}", code);
 
     let mut reply_msg: Message;
     let (mut compilation, mut execution, lang) = {

--- a/src/commands/exec/mod.rs
+++ b/src/commands/exec/mod.rs
@@ -411,9 +411,9 @@ fn exec(ctx: &mut Context, msg: &Message) -> CommandResult {
             	let tmp = tmp_split.take(2).collect::<Vec<_>>()[0] ;
             	code.insert_str(0,tmp);}
 	    else{
-		    let tmp = tmp_split.clone().take(2).collect::<Vec<_>>()[0] ;
+		    let tmp = tmp_split.clone().take(2).collect::<Vec<_>>()[1] ;
             	code.insert_str(0,tmp);
-		    let tmp_1 = tmp_split.take(2).collect::<Vec<_>>()[1] ;
+		    let tmp_1 = tmp_split.take(2).collect::<Vec<_>>()[2] ;
             	code.insert_str(0,tmp_1);
             }
         }

--- a/src/commands/exec/mod.rs
+++ b/src/commands/exec/mod.rs
@@ -326,11 +326,11 @@ fn exec(ctx: &mut Context, msg: &Message) -> CommandResult {
     let mut file_list = Vec::new();
     for attachment in attachments {
         match attachment.height {
-            Some(_) => {},
-            None => {file_list.push(attachment)},
+            Some(_) => {}, // Pictures have a height included
+            None => {file_list.push(attachment)}, // Other file don't
         }
     }
-    println!("Attachment lenght:{0} , Files{1}",attachments.len(),file_list.len());
+    // println!("Attachment lenght: {0} , Files: {1}",attachments.len(),file_list.len());
 
     let langs = data
         .get::<LangManager>()
@@ -346,6 +346,7 @@ fn exec(ctx: &mut Context, msg: &Message) -> CommandResult {
         return Ok(());
     } 
     else if split.clone().nth(1).is_none() {
+	println!("Second Case");
         while let Some(file) = file_list.pop() {
             let result = file.download();
             match result {
@@ -362,20 +363,27 @@ fn exec(ctx: &mut Context, msg: &Message) -> CommandResult {
                 Err(_) => {},
             }
         }
-    }
+   	}
     let mut code = String::new();
 
     match ret {
         None => {
             let tmp = split.take(2).collect::<Vec<_>>()[1];
             code.insert_str(0,tmp);
-
         },
         Some(t) => {
-            code = t ;
-            //code = t.take(2).collect::<Vec<_>>()[1];
+	    let tmp_split = t.split("```");
+	    if tmp_split.clone().nth(1).is_none() {
+            	let tmp = tmp_split.take(2).collect::<Vec<_>>()[0] ;
+            	code.insert_str(0,tmp);
+		}
+	    else{
+		let tmp = tmp_split.take(2).collect::<Vec<_>>()[1] ;
+            	code.insert_str(0,tmp);
+	    }
         }
     }
+    println!("Here is the code : {}", code);
 
     let mut split = code.split('\n');
     let (lang_code, code) = match split.next() {

--- a/src/commands/exec/mod.rs
+++ b/src/commands/exec/mod.rs
@@ -370,7 +370,7 @@ fn exec(ctx: &mut Context, msg: &Message) -> CommandResult {
             match result {
                 Ok(vector) => {
                     match String::from_utf8(vector) {
-                        Ok(result) =>{
+                        Ok(result) => {
                             _resultingstring.push_str(result.as_str());
                             ret = Some(_resultingstring);
                         },
@@ -381,7 +381,8 @@ fn exec(ctx: &mut Context, msg: &Message) -> CommandResult {
             }
         }
 	match ret {
-		Some(mut result) => {
+		Some(res_1) => {
+            let mut result= res_1.clone();
            	let mut tmp =String::new();
             let t = split.clone().take(2).collect::<Vec<_>>()[1];
             tmp.push_str(t);
@@ -395,7 +396,7 @@ fn exec(ctx: &mut Context, msg: &Message) -> CommandResult {
 	        None => {}
 	        }
             ret = Some(result)
-    }, None => {}}
+        }, None => {}}
     }
     let mut code = String::new();
     match ret {
@@ -404,6 +405,7 @@ fn exec(ctx: &mut Context, msg: &Message) -> CommandResult {
             code.insert_str(0,tmp);
         },
         Some(t) => {
+        println!("Here is the result: {}", code);
 	    let tmp_split = t.split("```");
 	        if tmp_split.clone().nth(1).is_none() {
             	let tmp = tmp_split.take(2).collect::<Vec<_>>()[0] ;

--- a/src/commands/exec/mod.rs
+++ b/src/commands/exec/mod.rs
@@ -405,7 +405,7 @@ fn exec(ctx: &mut Context, msg: &Message) -> CommandResult {
             code.insert_str(0,tmp);
         },
         Some(t) => {
-        println!("Here is the result: {}", code);
+        println!("Here is the result: {}", rt);
 	    let tmp_split = t.split("```");
 	        if tmp_split.clone().nth(1).is_none() {
             	let tmp = tmp_split.take(2).collect::<Vec<_>>()[0] ;

--- a/src/commands/exec/mod.rs
+++ b/src/commands/exec/mod.rs
@@ -389,14 +389,12 @@ fn exec(ctx: &mut Context, msg: &Message) -> CommandResult {
         },
         Some(t) => {
 	    let tmp_split = t.split("```");
-	    if tmp_split.clone().nth(1).is_none() {
+	        if tmp_split.clone().nth(1).is_none() {
             	let tmp = tmp_split.take(2).collect::<Vec<_>>()[0] ;
-            	code.insert_str(0,tmp);
-		}
+            	code.insert_str(0,tmp);}
 	    else{
-		let tmp = tmp_split.take(2).collect::<Vec<_>>()[1] ;
-            	code.insert_str(0,tmp);
-	    }
+		    let tmp = tmp_split.take(2).collect::<Vec<_>>()[1] ;
+            	code.insert_str(0,tmp);}
         }
     }
     println!("Here is the code : {}", code);

--- a/src/commands/exec/mod.rs
+++ b/src/commands/exec/mod.rs
@@ -405,14 +405,17 @@ fn exec(ctx: &mut Context, msg: &Message) -> CommandResult {
             code.insert_str(0,tmp);
         },
         Some(t) => {
-        println!("Here is the result: {}", rt);
+        println!("Here is the result: {}", t);
 	    let tmp_split = t.split("```");
 	        if tmp_split.clone().nth(1).is_none() {
             	let tmp = tmp_split.take(2).collect::<Vec<_>>()[0] ;
             	code.insert_str(0,tmp);}
 	    else{
-		    let tmp = tmp_split.take(2).collect::<Vec<_>>()[1] ;
-            	code.insert_str(0,tmp);}
+		    let tmp = tmp_split.clone().take(2).collect::<Vec<_>>()[0] ;
+            	code.insert_str(0,tmp);
+		    let tmp_1 = tmp_split.take(2).collect::<Vec<_>>()[1] ;
+            	code.insert_str(0,tmp_1);
+            }
         }
     }
     println!("Here is the code : {}", code);

--- a/src/commands/exec/mod.rs
+++ b/src/commands/exec/mod.rs
@@ -362,11 +362,12 @@ fn exec(ctx: &mut Context, msg: &Message) -> CommandResult {
             }
         }
     }
-    let tmp = split.clone().take(2).collect::<Vec<_>>().join("\n");
+    let tmp = split.take(2).collect::<Vec<_>>()[1];
     let mut split = tmp.split('\n');
     let (lang_code, text) = match split.next() {
         Some(line) => {
             let code = split.collect::<Vec<_>>().join("\n");
+            println!("Line {}", line);
             let lang = line.trim().to_ascii_lowercase();
             (lang, code)
         }


### PR DESCRIPTION
Well I did make a pull request the other day,
but this patch is now clean, small and actually working like intended.
How did I change the behaviour of the exec command?
If there is  a file, which is no picture, as attachement to the message,
the code of it will be appended to the front of the code snippet.
Just raw. 

### The philosophy
 behind that, and why actually appending code to your
code snippet.

 Well the idea of running code in your discord browser is nice, but why are we
actually using this feature. Since there is not much actual use for running code with
a maximum size of 2000 Characters in discord, I like to think this feature is for showing
things to other people and commonly debug things, or showing simple implementations
for small algorithms (for teaching). But even for that you would need to implement a
data base (graphs for example). And this is why I wanted to implement that feature.

### Why are the files read in raw
 and not written as markdown snippets like the discord source code.
It's because it's unlikely that your source code is actually like that, so
that would make work.

### How is the syntax now?
Just like with old format you still need to specify the language in the discord message
like before, but you won't need actually write code into the snippet.
So specifying it like this:
~exec
\`\`\`<language>
will be enough.

